### PR TITLE
[BUGFIX] Relative asset links on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,17 +41,17 @@ E: Unable to lock the administration directory (/var/lib/dpkg/), are you root?
 > *[Ubuntu](https://www.ubuntu.com/), and*
 > *[Void Linux](https://voidlinux.org/)*
 
-![Alpine Linux](https://raw.githubusercontent.com/keithieopia/piu/master/.readme-assets/brands/alpine.png "Alpine Linux") &nbsp;
-![Arch Linux](https://raw.githubusercontent.com/keithieopia/piu/master/.readme-assets/brands/arch.png "Arch Linux") &nbsp;
-![Linux Mint](https://raw.githubusercontent.com/keithieopia/piu/master/.readme-assets/brands/mint.png "Linux Mint") &nbsp;
-![macOS](https://raw.githubusercontent.com/keithieopia/piu/master/.readme-assets/brands/macos.png "macOS") &nbsp;
-![Ubuntu](https://raw.githubusercontent.com/keithieopia/piu/master/.readme-assets/brands/ubuntu.png "Ubuntu")
+![Alpine Linux](.readme-assets/brands/alpine.png "Alpine Linux") &nbsp;
+![Arch Linux](.readme-assets/brands/arch.png "Arch Linux") &nbsp;
+![Linux Mint](.readme-assets/brands/mint.png "Linux Mint") &nbsp;
+![macOS](.readme-assets/brands/macos.png "macOS") &nbsp;
+![Ubuntu](.readme-assets/brands/ubuntu.png "Ubuntu")
 &nbsp;
-![Elementary OS](https://raw.githubusercontent.com/keithieopia/piu/master/.readme-assets/brands/elementary.png "Elementary OS") &nbsp;
-![Debian](https://raw.githubusercontent.com/keithieopia/piu/master/.readme-assets/brands/debian.png "Debian") &nbsp;
-![Manjaro](https://raw.githubusercontent.com/keithieopia/piu/master/.readme-assets/brands/manjaro.png "Manjaro") &nbsp;
-![Fedora](https://raw.githubusercontent.com/keithieopia/piu/master/.readme-assets/brands/fedora.png "Fedora") &nbsp;
-![Void Linux](https://raw.githubusercontent.com/keithieopia/piu/master/.readme-assets/brands/void.png "Void Linux")
+![Elementary OS](.readme-assets/brands/elementary.png "Elementary OS") &nbsp;
+![Debian](.readme-assets/brands/debian.png "Debian") &nbsp;
+![Manjaro](.readme-assets/brands/manjaro.png "Manjaro") &nbsp;
+![Fedora](.readme-assets/brands/fedora.png "Fedora") &nbsp;
+![Void Linux](.readme-assets/brands/void.png "Void Linux")
 &nbsp;
 > :copyright: *above brands, logos, and trademarks are property of
 their respective owners.*

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # piu (Platform Independant Updater)
 
-<img align="right" alt="Skunk Logo" src="https://raw.githubusercontent.com/keithieopia/piu/master/.readme-assets/logo/skunk-logo.png">
+<img align="right" alt="Skunk Logo" src=".readme-assets/logo/skunk-logo.png">
 
 **`piu` makes cross-platform package management stink less.**
 


### PR DESCRIPTION
Links to assets point to author's repository master branch. This breaks work on different branches and/or forks.

This PR changes the links to be relative to the repo/branch.

Resources:
https://github.blog/2013-01-31-relative-links-in-markup-files/