### PR TITLE
[BUGFIX] Parsing date from pacman log + bats tests

### DIFF
--- a/piu
+++ b/piu
@@ -96,7 +96,7 @@ pacman_repo_age() {
 }
 
 pacman_repo_update() {
-	if ! sudo pacman -Sy &> /dev/null; then
+	if ! sudo -n pacman -Sy &> /dev/null; then
 		echo "out-of-date"
 		exit 1
 	fi

--- a/piu
+++ b/piu
@@ -82,14 +82,21 @@ pacman_search()  { pacman -Ss "$@"; }
 pacman_list()    { pacman -Qqe; }
 pacman_manual()  { sudo pacman -U "$@"; }
 
+
+pacman_extract_date_from_log_line() {
+	date_string=`echo $1 | sed "s/] .*/]/" | sed -e 's/\[\(.*\)\]/\1/g'`
+	date -d "$date_string" +%s
+}
+
 pacman_repo_age() {
-	LOG_DATE=$(grep 'synchronizing package lists' /var/log/pacman.log | \
-               tail -1 | awk '{print $1" "$2}' | tr -d \[\])
-	date -d "$LOG_DATE" +%s
+	LOG_LINE=$(grep 'synchronizing package lists' /var/log/pacman.log | \
+		tail -1)
+	LOG_DATE=`pacman_extract_date_from_log_line "$LOG_LINE"`
+	echo $LOG_DATE
 }
 
 pacman_repo_update() {
-	if ! sudo -n pacman -Sy &> /dev/null; then
+	if ! sudo pacman -Sy &> /dev/null; then
 		echo "out-of-date"
 		exit 1
 	fi
@@ -322,6 +329,9 @@ case "$action" in
 
 	m | manual)
 		eval ${PKGMAN}_manual
+		;;
+
+	pass)
 		;;
 
 	*)

--- a/piu
+++ b/piu
@@ -331,9 +331,6 @@ case "$action" in
 		eval ${PKGMAN}_manual
 		;;
 
-	pass)
-		;;
-
 	*)
 		usage
 		;;

--- a/piu.bats
+++ b/piu.bats
@@ -1,0 +1,21 @@
+#!/usr/bin/env bats
+
+source ./piu
+
+@test "pacman_extract_date_from_log_line works on 'Linux 5.4.17-1-MANJARO'" {
+
+	log_line="[2020-02-06T21:24:46+0000] [PACMAN] synchronizing package lists"
+
+	date_string=`pacman_extract_date_from_log_line "$log_line"`
+
+	[ "$date_string" == "1581024286" ]
+}
+
+@test "pacman_extract_date_from_log_line works on 'Linux 5.2.11-arch1-ARCH'" {
+
+	log_line="[2020-02-06 21:24] [PACMAN] synchronizing package lists"
+
+	date_string=`pacman_extract_date_from_log_line "$log_line"`
+
+	[ "$date_string" == "1581024240" ]
+}


### PR DESCRIPTION
## Description

Running `./piu install git` throws error:
```
date: invalid date ‘2020-02-09T22:29:32+0000 PACMAN’
```

## System
Manjaro Linux, i3-wm
```
Linux 5.4.17-1-MANJARO #1 SMP PREEMPT Tue Feb 4 11:40:50 UTC 2020 x86_64 GNU/Linux
```

## Fix:
Parsing log-line using different logic. Extract content within first brackets and pass that into the date command.

Added bats test file.