### PR TITLE
[FEATURE] Support passing the 'cask' argument for osx cask 

### DIFF
--- a/piu
+++ b/piu
@@ -6,7 +6,7 @@ usage() {
 cat <<HELP
 Cross-platform package manager wrapper
 
-usage: $(basename "$0") OPTION [PACKAGE]
+usage: $(basename "$0") [cask] OPTION [PACKAGE]
 
    SINGLE PACKAGE ACTIONS
    (i)nstall : install a given package
@@ -211,11 +211,11 @@ dnf_num_pkgs() {
 # macOS
 #
 
-brew_install() { brew install "$@"; }
-brew_update()  { brew upgrade; }
-brew_remove()  { brew uninstall "$@"; }
-brew_search()  { brew search "$@"; }
-brew_list()    { brew list; }
+brew_install() { brew $BREW_CASK install "$@"; }
+brew_update()  { brew $BREW_CASK upgrade; }
+brew_remove()  { brew $BREW_CASK uninstall "$@"; }
+brew_search()  { brew $BREW_CASK search "$@"; }
+brew_list()    { brew $BREW_CASK list; }
 
 brew_repo_age() {
 	date +%s
@@ -279,10 +279,17 @@ fi
 
 # make leading dashes optional, out of tradition
 if is_darwin; then
+  # Detect cask argument
+  if [ "$1" == "cask" ]; then
+    BREW_CASK="cask"
+    shift 1
+  fi
+
   action=$(echo "$1" | sed 's/^-*//g')
 else
   action=$(echo "$1" | sed 's/^-*//g' --)
 fi
+
 
 case "$action" in
 	s | search)

--- a/piu
+++ b/piu
@@ -290,7 +290,6 @@ else
   action=$(echo "$1" | sed 's/^-*//g' --)
 fi
 
-
 case "$action" in
 	s | search)
 		shift 1

--- a/piu.bats
+++ b/piu.bats
@@ -1,6 +1,13 @@
 #!/usr/bin/env bats
 
-source ./piu
+# brew stub
+function brew () { echo $@; }
+
+load ./piu
+
+setup() {
+  export -f brew
+}
 
 @test "pacman_extract_date_from_log_line works on 'Linux 5.4.17-1-MANJARO'" {
 
@@ -18,4 +25,17 @@ source ./piu
 	date_string=`pacman_extract_date_from_log_line "$log_line"`
 
 	[ "$date_string" == "1581024240" ]
+}
+
+@test "[OSX] proxies the 'cask' argument to brew" {
+
+	run ./piu install aPackage
+	[ "$output" == "install aPackage" ]
+
+	run ./piu cask install aPackage
+	[ "$output" == "cask install aPackage" ]
+}
+
+teardown() {
+  unset -f brew
 }


### PR DESCRIPTION
Many usefull software can be installed using `brew cask install [package]` under osx. This change modifies `piu` to accept the optional `cask` argument`.