### PR TITLE
Updates to brew interface, more tests

### DIFF
--- a/piu
+++ b/piu
@@ -261,7 +261,8 @@ brew_update()  { brew $BREW_CASK upgrade; }
 brew_remove()  { brew $BREW_CASK uninstall "$@"; }
 brew_search()  { brew $BREW_CASK search "$@"; }
 brew_list()    { brew $BREW_CASK list; }
-brew_manual()    { not_implemented; }
+brew_manual()  { not_implemented; }
+brew_cache()   { not_implemented; }
 
 brew_repo_age() {
 	date +%s
@@ -272,7 +273,7 @@ brew_repo_update() {
 }
 
 brew_num_updates() {
-	echo "not implemented yet!" && exit 1;
+  not_implemented;
 }
 
 brew_num_pkgs() {

--- a/piu
+++ b/piu
@@ -37,6 +37,13 @@ HELP
 }
 
 
+# Utils
+########################################################################
+not_implemented() {
+  echo "'${FUNCNAME[1]}' not implemented yet!" && exit 1
+}
+
+
 # Distro Specific
 ########################################################################
 
@@ -45,7 +52,7 @@ HELP
 #
 
 # WONTFIX:
-# piu depends on bash, which isn't in the base install of Alpine. 
+# piu depends on bash, which isn't in the base install of Alpine.
 # Without it, the following error occurs: "-ash: piu: not found"
 apk_install() { sudo apk add "$@"; }
 apk_update()  { sudo apk upgrade; }
@@ -54,8 +61,8 @@ apk_purge()   { sudo apk del "$@" && sudo apk cache clean; }
 apk_search()  { apk search -v "$@"; }
 apk_list()    { apk info; }
 apk_list_files() {
-	# WONTFIX: 
-	# It seems that file content listings are optional with apks, such as 
+	# WONTFIX:
+	# It seems that file content listings are optional with apks, such as
 	# with `joe` and`nano`; apk will fail silently with $? as a success.
 	apk info -L "$@"
 }
@@ -96,12 +103,12 @@ pacman_list_files() {
 	# The below code will fail on similar named packages
 	# like chromium and chromium-bsu. The problem is two-fold
 	#
-	# 1. pacman searching needs to use ^PACKAGE$ to match 
-	# exact names. `pacman -Qs $$@^` doesn't work, but how to 
+	# 1. pacman searching needs to use ^PACKAGE$ to match
+	# exact names. `pacman -Qs $$@^` doesn't work, but how to
 	# properly escape is beyond me.
 	#
 	# 2. Output from `pacman -Sw` should be captured to get the
-	# exact filename of the package. Calling `ls` is sloppy 
+	# exact filename of the package. Calling `ls` is sloppy
 
 	if ! pacman -Qs "$@" >/dev/null; then
 		sudo pacman -Sw --noconfirm "$@"
@@ -142,7 +149,7 @@ xbps_purge()   { sudo xbps-remove -R "$@" && sudo xbps-remove -Oo; }
 xbps_search()  { xbps-query -Rs "$@"; }
 xbps_list()    { xbps-query -l; }
 xbps_list_files() { xbps-query -Rf "$@"; }
-xbps_manual()  { 
+xbps_manual()  {
 	xbps-rindex -a *.xbps
 	xbps-install --repository=$PWD "$@"
 }
@@ -178,7 +185,7 @@ apt_search()  { apt search "$@"; }
 apt_list()    { dpkg-query -f '${binary:Package}\n' -W; }
 apt_list_files() {
 	if ! apt list --installed 2>/dev/null | grep -q "$@"; then
-		# using apt-get prevents dependencies from downloading 
+		# using apt-get prevents dependencies from downloading
 		# and doesn't need sudo
 		DIR=$(mktemp -d)
 		(cd $DIR && apt-get download "$@" > /dev/null 2>&1)
@@ -254,6 +261,7 @@ brew_update()  { brew $BREW_CASK upgrade; }
 brew_remove()  { brew $BREW_CASK uninstall "$@"; }
 brew_search()  { brew $BREW_CASK search "$@"; }
 brew_list()    { brew $BREW_CASK list; }
+brew_manual()    { not_implemented; }
 
 brew_repo_age() {
 	date +%s

--- a/piu
+++ b/piu
@@ -263,6 +263,7 @@ brew_search()  { brew $BREW_CASK search "$@"; }
 brew_list()    { brew $BREW_CASK list; }
 brew_manual()  { not_implemented; }
 brew_cache()   { not_implemented; }
+brew_purge()   { not_implemented; }
 
 brew_repo_age() {
 	date +%s

--- a/piu
+++ b/piu
@@ -39,10 +39,10 @@ HELP
 
 # Utils
 ########################################################################
+
 not_implemented() {
   echo "'${FUNCNAME[1]}' not implemented yet!" && exit 1
 }
-
 
 # Distro Specific
 ########################################################################
@@ -262,8 +262,9 @@ brew_remove()  { brew $BREW_CASK uninstall "$@"; }
 brew_search()  { brew $BREW_CASK search "$@"; }
 brew_list()    { brew $BREW_CASK list; }
 brew_manual()  { not_implemented; }
-brew_cache()   { not_implemented; }
 brew_purge()   { not_implemented; }
+
+brew_list_files() { not_implemented; }
 
 brew_repo_age() {
 	date +%s

--- a/piu
+++ b/piu
@@ -6,7 +6,7 @@ usage() {
 cat <<HELP
 Cross-platform package manager wrapper
 
-usage: $(basename "$0") [cask] OPTION [PACKAGE]
+usage: $(basename "$0") OPTION [--cask] [PACKAGE]
 
    SINGLE PACKAGE ACTIONS
    (i)nstall : install a given package

--- a/piu.bats
+++ b/piu.bats
@@ -11,6 +11,20 @@ setup() {
   export -f uname
 }
 
+@test "'not_implemented' shows error message and exits" {
+
+  # TODO: Test the exit code. Will require integration of the bats-support and
+  # bats-assert libraries
+
+  we_did_not_implement_this() {
+    not_implemented;
+  }
+
+  run we_did_not_implement_this
+
+	[ "$output" == "'we_did_not_implement_this' not implemented yet!" ]
+}
+
 @test "[OSX] proxies the 'cask' argument to brew" {
 
 	run ./piu install aPackage
@@ -18,6 +32,15 @@ setup() {
 
 	run ./piu cask install aPackage
 	[ "$output" == "cask install aPackage" ]
+
+	run ./piu install --cask aPackage
+	[ "$output" == "install --cask aPackage" ]
+}
+
+@test "[OSX] implements the manual command" {
+
+	run ./piu manual aPackage
+	[ "$output" == "'brew_manual' not implemented yet!" ]
 }
 
 teardown() {

--- a/piu.bats
+++ b/piu.bats
@@ -1,6 +1,12 @@
 #!/usr/bin/env bats
 
+FUNC_NAMES="search remove purge list list_files install update num_updates \
+num_pkgs repo_update manual"
+
 # brew stub
+function brew () { echo $@; }
+
+# uname stub
 function brew () { echo $@; }
 function uname () { echo "Darwin"; }
 
@@ -22,25 +28,46 @@ setup() {
 
   run we_did_not_implement_this
 
-	[ "$output" == "'we_did_not_implement_this' not implemented yet!" ]
+  [ "$output" == "'we_did_not_implement_this' not implemented yet!" ]
 }
 
-@test "[OSX] proxies the 'cask' argument to brew" {
 
-	run ./piu install aPackage
-	[ "$output" == "install aPackage" ]
+# Brew
+########################################################################
 
-	run ./piu cask install aPackage
-	[ "$output" == "cask install aPackage" ]
+@test "[BREW] implements the interface" {
 
-	run ./piu install --cask aPackage
-	[ "$output" == "install --cask aPackage" ]
+ for func in ${FUNC_NAMES[@]};
+ do
+  declare -f -F "brew_$func";
+
+  [ "$?" == "0" ];
+ done
 }
 
-@test "[OSX] implements the manual command" {
+@test "[BREW] proxies the 'cask' argument to brew" {
 
-	run ./piu manual aPackage
-	[ "$output" == "'brew_manual' not implemented yet!" ]
+  run ./piu install aPackage
+  [ "$output" == "install aPackage" ]
+
+  run ./piu cask install aPackage
+  [ "$output" == "cask install aPackage" ]
+
+  run ./piu install --cask aPackage
+  [ "$output" == "install --cask aPackage" ]
+}
+
+# Apt
+########################################################################
+
+@test "[APT] implements the interface" {
+
+ for func in ${FUNC_NAMES[@]};
+ do
+  declare -f -F "apt_$func";
+
+  [ "$?" == "0" ];
+ done
 }
 
 teardown() {

--- a/piu.bats
+++ b/piu.bats
@@ -7,7 +7,6 @@ num_pkgs repo_update manual"
 function brew () { echo $@; }
 
 # uname stub
-function brew () { echo $@; }
 function uname () { echo "Darwin"; }
 
 load ./piu
@@ -17,7 +16,7 @@ setup() {
   export -f uname
 }
 
-@test "'not_implemented' shows error message and exits" {
+@test "[UTIL] 'not_implemented' shows error message and exits" {
 
   # TODO: Test the exit code. Will require integration of the bats-support and
   # bats-assert libraries


### PR DESCRIPTION
The initial motivation here was to ensure `piu` correctly proxies the `--cask` parameter which is now the prefered argument for `brew`.

```
$ brew cask install docker
Warning: Calling brew cask install is deprecated! Use brew install [--cask] instead.
```

Seeing how the interface evolved I also added a `not_implemented` utility for easily flagging functions and added test cases to ensure the whole interface is implemented by the package manager wrappers (currently added tests only for `brew` and `apt`)